### PR TITLE
Fix for provided types

### DIFF
--- a/src/BigQueryProvider/BigQueryCommandProvider.fs
+++ b/src/BigQueryProvider/BigQueryCommandProvider.fs
@@ -11,43 +11,43 @@ open ProcessHelper
 
 [<TypeProvider>]
 [<CompilerMessageAttribute("This API supports the BigQueryProvider infrastructure and is not intended to be used directly from your code.", 101, IsHidden = true)>]
-type BigQueryCommandProvider (config: TypeProviderConfig) as this = 
+type BigQueryCommandProvider (config: TypeProviderConfig) as this =
   inherit TypeProviderForNamespaces()
   let nameSpace = this.GetType().Namespace
   let assembly = Assembly.GetExecutingAssembly()
 
-  do 
-    printfn "Assembly name: %A" assembly.FullName 
+  do
+    printfn "Assembly name: %A" assembly.FullName
   let providerType = ProvidedTypeDefinition(assembly, nameSpace, "BigQueryCommandProvider", Some typeof<obj>, HideObjectMethods = true)
 
   do
     providerType.DefineStaticParameters(
-            parameters = [ 
-                ProvidedStaticParameter("CommandText", typeof<string>) 
-            ],             
+            parameters = [
+                ProvidedStaticParameter("CommandText", typeof<string>)
+            ],
             instantiationFunction = (fun typeName [|commandText|] ->
                 let value = this.CreateRootType(typeName, unbox commandText)
                 value
-            ) 
+            )
         )
 
   do
     this.AddNamespace(nameSpace, [providerType])
 
-  member this.CreateRootType(typeName, commandText) = 
+  member this.CreateRootType(typeName, commandText) =
 
-    let rootType = ProvidedTypeDefinition(assembly, nameSpace, typeName, Some typeof<obj>, HideObjectMethods = false)
-      
-    let schema = 
+    let rootType = ProvidedTypeDefinition(assembly, nameSpace, typeName, Some typeof<obj>, HideObjectMethods = true)
+
+    let schema =
         commandText
         |> BigQueryHelper.analyzeQueryRaw
         |> (fun y -> y.stdout)
         |> SchemaHandling.Parsing.parseQueryMeta
 
     let providedOutputType = DesignTime.createOutputType providerType schema
-    
+
     DesignTime.createCommandCtors rootType
-    |> List.append (DesignTime.createExecute rootType commandText providedOutputType)
+    |> List.append (DesignTime.createExecute commandText providedOutputType)
     |> List.append ([providedOutputType])
     |> rootType.AddMembers
     rootType


### PR DESCRIPTION
First commit should fix provided `Row` type, you should not specify assembly type and namespace for nested types like this `ProvidedTypeDefinition(rootType.Assembly, rootType.Namespace, ...`

(sorry my editor remove training whitespaces automatically)

<img width="682" alt="bqtp" src="https://cloud.githubusercontent.com/assets/1197905/24708746/82cd3d36-1a20-11e7-8fdf-add5b2bc4b9a.png">
