### PR TITLE
Fix for execute()

### DIFF
--- a/src/BigQueryProvider/DesignTime.fs
+++ b/src/BigQueryProvider/DesignTime.fs
@@ -61,19 +61,26 @@ let createExecute (commandText: string) providedOutputType : MemberInfo list =
     [
         let m = ProvidedMethod("execute", [], providedOutputType)
         m.InvokeCode <- fun exprArgs ->
+            let schema = // TODO: you can pass schema here, instead of commandText
+                (BigQueryHelper.analyzeQueryRaw commandText).stdout
+                |> parseQueryMeta
+            let (names, indexes) =
+                schema.Fields
+                |> List.choose (fun y ->
+                   match y with
+                   | Value(index, name, _, _) ->
+                        Some((string)name, (int)index)
+                   | _ -> None)
+                |> List.toArray
+                |> Array.unzip
             let mapping =
                 <@@
                     fun (row: obj[]) ->
-                        let schema =
-                            (BigQueryHelper.analyzeQueryRaw commandText).stdout
-                            |> parseQueryMeta
                         let data = System.Collections.Generic.Dictionary()
-                        schema.Fields
-                        |> List.iter (fun y ->
-                            match y with
-                            | Value(index, name, fieldType, mode) ->
-                                data.Add(name, row.[index])
-                            | _ -> ())
+                        Array.zip names indexes
+                        |> Array.iter (fun (name, index) ->
+                            data.Add(name, row.[index])
+                        )
                         DynamicRecord(data) |> box
                 @@>
             <@@


### PR DESCRIPTION
Now TP complain that you use pattern match on you value type.
Not sure that I understand why it cannot find this type in assembly (after quotation compilation) ... 

But you have to reasons to reevaluate schema in runtime and everything can be done in compile time.
Arrays and basic types calculated in design time can be used from quotations 

<img width="1286" alt="bqtp_2" src="https://cloud.githubusercontent.com/assets/1197905/24709752/a2bfbbb6-1a23-11e7-9694-663664921e11.png">
