### PR TITLE
evaluate schema in runtime

### DIFF
--- a/src/BigQueryProvider/DesignTime.fs
+++ b/src/BigQueryProvider/DesignTime.fs
@@ -57,35 +57,26 @@ let internal createOutputType (rootType:ProvidedTypeDefinition) (schema: Schema)
 
     recordType
 
+let execImpl commandText (row: obj[]) =
+    let schema =
+        (BigQueryHelper.analyzeQueryRaw commandText).stdout
+        |> parseQueryMeta
+    let data = System.Collections.Generic.Dictionary()
+    schema.Fields
+    |> List.iter (fun y ->
+        match y with
+        | Value(index, name, _, _) ->
+            data.Add((string)name, row.[(int)index])
+        | _ -> ())
+    DynamicRecord(data)
+
 let createExecute (commandText: string) providedOutputType : MemberInfo list =
     [
         let m = ProvidedMethod("execute", [], providedOutputType)
         m.InvokeCode <- fun exprArgs ->
-            let schema = // TODO: you can pass schema here, instead of commandText
-                (BigQueryHelper.analyzeQueryRaw commandText).stdout
-                |> parseQueryMeta
-            let (names, indexes) =
-                schema.Fields
-                |> List.choose (fun y ->
-                   match y with
-                   | Value(index, name, _, _) ->
-                        Some((string)name, (int)index)
-                   | _ -> None)
-                |> List.toArray
-                |> Array.unzip
-            let mapping =
-                <@@
-                    fun (row: obj[]) ->
-                        let data = System.Collections.Generic.Dictionary()
-                        Array.zip names indexes
-                        |> Array.iter (fun (name, index) ->
-                            data.Add(name, row.[index])
-                        )
-                        DynamicRecord(data) |> box
-                @@>
             <@@
                 let result = analyzeQueryRaw commandText
-                (%%mapping) ([|result.stdout :> obj|])
+                execImpl commandText ([|result.stdout :> obj|])
             @@>
 
         yield m :> MemberInfo


### PR DESCRIPTION
The solution that should work for you.
The rule of thumb - "do not write complicated quotation, implement everything as usual F# code".

Just note that code emitted by Tp will call `execImpl` and this function should be referenced from the client assembly (so you can not define it as `private` or `internal`). If you decide one day  to split you TP in multiple assemblies, do not forget to keep `execImpl` in assembly that exist in runtime